### PR TITLE
Ruleapplier and fixing rules to use Notes instead of Ints

### DIFF
--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -66,6 +66,7 @@ namespace CounterpointGenerator
             List<Note> output = new List<Note>();
             for (int addPitch = lowerPitch; addPitch <= upperPitch; addPitch++)
             {
+                // TODO: Fix for note length when that becomes something to worry about
                 output.Add(new Note(addPitch));
             }
             return output;

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -6,7 +6,7 @@ namespace CounterpointGenerator
 {
     public class Generator: IGenerator
     {
-        private readonly RuleApplier ruleApplier;
+        private RuleApplier ruleApplier;
 
         private List<MelodyLine> GenerateCounterpoint(MelodyLine inputCantusfirmus)
         {
@@ -46,6 +46,7 @@ namespace CounterpointGenerator
             // Possibilities, currentNote, position, length, previousCantus, previousCounterpoint
             RuleInput ruleInput = new RuleInput(possibleNotes, n, generateCount, melodyLength, prevN, preCtp);
 
+            ruleApplier = new RuleApplier();
             if (ruleApplier.GenerateSet())
             {
                 ruleApplier.Applicator(ruleInput);

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -10,13 +10,13 @@ namespace CounterpointGenerator
 
         private List<MelodyLine> GenerateCounterpoint(MelodyLine inputCantusfirmus)
         {
-            return GenerateCounterpointForNoteStack(inputCantusfirmus, null, null, 0);
+            return GenerateCounterpointForNoteStack(inputCantusfirmus, null, null, 0, inputCantusfirmus.Length());
         }
 
-        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote, int count)
+        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote, int count, int fullLength)
         {
             Note n = m.FirstNote;
-            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, m.Length(), count);
+            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, fullLength, count);
 
             List<MelodyLine> solutionList = new List<MelodyLine>();
             IWeightSelect weightSelector = new WeightSelect();
@@ -26,7 +26,7 @@ namespace CounterpointGenerator
             foreach (Note p in subListToExplore)
             {
          
-                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(m, n, p, count + 1);
+                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(m, n, p, count + 1, fullLength);
                 List<MelodyLine> solution = new List<MelodyLine>();
                 foreach (MelodyLine line in melodyList)
                 {

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -6,17 +6,17 @@ namespace CounterpointGenerator
 {
     public class Generator: IGenerator
     {
-        //RuleApplier _applier;
+        private readonly RuleApplier ruleApplier;
 
         private List<MelodyLine> GenerateCounterpoint(MelodyLine inputCantusfirmus)
         {
-            return GenerateCounterpointForNoteStack(inputCantusfirmus, null, null);
+            return GenerateCounterpointForNoteStack(inputCantusfirmus, null, null, 0);
         }
 
-        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote)
+        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote, int count)
         {
             Note n = m.FirstNote;
-            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote);
+            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, m.Length(), count);
 
             List<MelodyLine> solutionList = new List<MelodyLine>();
             IWeightSelect weightSelector = new WeightSelect();
@@ -26,7 +26,7 @@ namespace CounterpointGenerator
             foreach (Note p in subListToExplore)
             {
          
-                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(m, n, p);
+                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(m, n, p, count + 1);
                 List<MelodyLine> solution = new List<MelodyLine>();
                 foreach (MelodyLine line in melodyList)
                 {
@@ -40,21 +40,34 @@ namespace CounterpointGenerator
 
         }
 
-        private List<Note> CounterpointForNote(Note n, Note prevN, Note preCtp)
+        private List<Note> CounterpointForNote(Note n, Note prevN, Note preCtp, int melodyLength, int generateCount)
         {
             List<Note> possibleNotes = GenerateNoteAtRegion(n);
-            List<Note> possibleNotesAfterRules = new List<Note>();
-            /*foreach(IRules r in Dictionary[input.userPreference])
+            // Possibilities, currentNote, position, length, previousCantus, previousCounterpoint
+            RuleInput ruleInput = new RuleInput(possibleNotes, n, generateCount, melodyLength, prevN, preCtp);
+
+            if (ruleApplier.GenerateSet())
             {
-                List<Note> newPossibleNotes = r.Apply(possibleNotes);
-                possibleNotesAfterRules.AddRange(newPossibleNotes);
-            }*/
-            return possibleNotesAfterRules;
+                ruleApplier.Applicator(ruleInput);
+            }
+            else
+            {
+                throw new Exception("Ruleset did not generate properly!");
+            }
+
+            return ruleInput.Possibilities;
         }
 
         private List<Note> GenerateNoteAtRegion(Note n)
         {
-            throw new NotImplementedException();
+            int upperPitch = n.Pitch + 13; // +1 octave
+            int lowerPitch = n.Pitch - 13; // -1 octave
+            List<Note> output = new List<Note>();
+            for (int addPitch = lowerPitch; addPitch <= upperPitch; addPitch++)
+            {
+                output.Add(new Note(addPitch));
+            }
+            return output;
         }
 
         public Task<IOutput> Generate(IInput input)

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -61,8 +61,8 @@ namespace CounterpointGenerator
 
         private List<Note> GenerateNoteAtRegion(Note n)
         {
-            int upperPitch = n.Pitch + 13; // +1 octave
-            int lowerPitch = n.Pitch - 13; // -1 octave
+            int upperPitch = n.Pitch + Note.OCTAVE; // +1 octave
+            int lowerPitch = n.Pitch - Note.OCTAVE; // -1 octave
             List<Note> output = new List<Note>();
             for (int addPitch = lowerPitch; addPitch <= upperPitch; addPitch++)
             {

--- a/CounterpointGenerator/CounterpointGenerator/MelodyLine.cs
+++ b/CounterpointGenerator/CounterpointGenerator/MelodyLine.cs
@@ -30,6 +30,11 @@ namespace CounterpointGenerator
             this.AMelodyLine.Insert(0, firstCounterNote);
         }
 
+        public int Length()
+        {
+            return AMelodyLine.Count;
+        }
+
         public MelodyLine()
         {
             this.AMelodyLine = new List<Note>();

--- a/CounterpointGenerator/CounterpointGenerator/Note.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Note.cs
@@ -3,6 +3,9 @@ namespace CounterpointGenerator
 {
     public class Note
     {
+        // One octave is thirteen semitones
+        public static int OCTAVE = 13;
+
         public int Pitch { get; set; }
         public int Length { get; set; } = 4; //Measure in beats, default whole note
 

--- a/CounterpointGenerator/CounterpointGenerator/Note.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Note.cs
@@ -3,11 +3,12 @@ namespace CounterpointGenerator
 {
     public class Note
     {
-        int NoteUnit { get; set; }
+        public int Pitch { get; set; }
+        public int Length { get; set; } = 4; //Measure in beats, default whole note
 
-        /*public Note()
+        public Note(int pitch)
         {
+            this.Pitch = pitch;
         }
-        */
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Note.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Note.cs
@@ -11,6 +11,12 @@ namespace CounterpointGenerator
             this.Pitch = pitch;
         }
 
+        public Note(int pitch, int length)
+        {
+            this.Pitch = pitch;
+            this.Length = length;
+        }
+
         public Boolean Equals(Note n)
         {
             return (this.Pitch == n.Pitch && this.Length == n.Length);

--- a/CounterpointGenerator/CounterpointGenerator/Note.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Note.cs
@@ -10,5 +10,10 @@ namespace CounterpointGenerator
         {
             this.Pitch = pitch;
         }
+
+        public Boolean Equals(Note n)
+        {
+            return (this.Pitch == n.Pitch && this.Length == n.Length);
+        }
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -15,6 +15,12 @@ namespace CounterpointGenerator
          */
         public List<int> Apply(RuleInput ruleInput)
         {
+            // Do nothing if no previous notes!
+            if (ruleInput.Position == 0)
+            {
+                return ruleInput.Possibilities;
+            }
+
             List<int> output = new List<int>(ruleInput.Possibilities);
             // Check if previous cantus stepped up
             if (ruleInput.PreviousCantus < ruleInput.CurrentNote)

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -23,28 +23,24 @@ namespace CounterpointGenerator
 
             List<Note> output = new List<Note>(ruleInput.Possibilities);
             // Check if previous cantus stepped up
-            if (ruleInput.PreviousCantus.Pitch < ruleInput.CurrentNote.Pitch)
+            // Check if previous counterpoint was the higher voice
+            if (ruleInput.PreviousCantus.Pitch < ruleInput.CurrentNote.Pitch && 
+                ruleInput.PreviousCounterpoint.Pitch > ruleInput.PreviousCantus.Pitch)
             {
-                // Check if previous counterpoint was the higher voice
-                if(ruleInput.PreviousCounterpoint.Pitch > ruleInput.PreviousCantus.Pitch)
-                {
-                    // Remove upper octave as a possibility
-                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13, ruleInput.CurrentNote.Length);
-                    // Remove all items n such that n's pitch is equal to the removeNote pitch
-                    output.RemoveAll(n => n.Pitch == removeNote.Pitch);
-                }
+                // Remove upper octave as a possibility
+                Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13, ruleInput.CurrentNote.Length);
+                // Remove all items n such that n's pitch is equal to the removeNote pitch
+                output.RemoveAll(n => n.Pitch == removeNote.Pitch);
             }
             // Check if previous cantus stepped down
-            else if (ruleInput.PreviousCantus.Pitch > ruleInput.CurrentNote.Pitch)
+            // Check if previous counterpoint was the lower voice
+            else if (ruleInput.PreviousCantus.Pitch > ruleInput.CurrentNote.Pitch &&
+                ruleInput.PreviousCounterpoint.Pitch < ruleInput.PreviousCantus.Pitch)
             {
-                // Check if previous counterpoint was the lower voice
-                if(ruleInput.PreviousCounterpoint.Pitch < ruleInput.PreviousCantus.Pitch)
-                {
-                    // Remove lower octave as a possibility
-                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13, ruleInput.CurrentNote.Length);
-                    // Remove all items n such that n's pitch is equal to the removeNote pitch
-                    output.RemoveAll(n => n.Pitch == removeNote.Pitch);
-                }
+                // Remove lower octave as a possibility
+                Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13, ruleInput.CurrentNote.Length);
+                // Remove all items n such that n's pitch is equal to the removeNote pitch
+                output.RemoveAll(n => n.Pitch == removeNote.Pitch);
             }
             return output;
         }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -30,6 +30,7 @@ namespace CounterpointGenerator
                 {
                     // Remove upper octave as a possibility
                     Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13, ruleInput.CurrentNote.Length);
+                    // Remove all items n such that n's pitch is equal to the removeNote pitch
                     output.RemoveAll(n => n.Pitch == removeNote.Pitch);
                 }
             }
@@ -41,6 +42,7 @@ namespace CounterpointGenerator
                 {
                     // Remove lower octave as a possibility
                     Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13, ruleInput.CurrentNote.Length);
+                    // Remove all items n such that n's pitch is equal to the removeNote pitch
                     output.RemoveAll(n => n.Pitch == removeNote.Pitch);
                 }
             }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -28,9 +28,8 @@ namespace CounterpointGenerator
                 ruleInput.PreviousCounterpoint.Pitch > ruleInput.PreviousCantus.Pitch)
             {
                 // Remove upper octave as a possibility
-                Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13, ruleInput.CurrentNote.Length);
                 // Remove all items n such that n's pitch is equal to the removeNote pitch
-                output.RemoveAll(n => n.Pitch == removeNote.Pitch);
+                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch + Note.OCTAVE);
             }
             // Check if previous cantus stepped down
             // Check if previous counterpoint was the lower voice
@@ -38,9 +37,8 @@ namespace CounterpointGenerator
                 ruleInput.PreviousCounterpoint.Pitch < ruleInput.PreviousCantus.Pitch)
             {
                 // Remove lower octave as a possibility
-                Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13, ruleInput.CurrentNote.Length);
                 // Remove all items n such that n's pitch is equal to the removeNote pitch
-                output.RemoveAll(n => n.Pitch == removeNote.Pitch);
+                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch - Note.OCTAVE);
             }
             return output;
         }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -13,7 +13,7 @@ namespace CounterpointGenerator
         /**
          * INPUTS: Possibilities, CurrentNote, PreviousCantus, PreviousCounterpoint
          */
-        public List<int> Apply(RuleInput ruleInput)
+        public List<Note> Apply(RuleInput ruleInput)
         {
             // Do nothing if no previous notes!
             if (ruleInput.Position == 0)
@@ -21,25 +21,29 @@ namespace CounterpointGenerator
                 return ruleInput.Possibilities;
             }
 
-            List<int> output = new List<int>(ruleInput.Possibilities);
+            List<Note> output = new List<Note>(ruleInput.Possibilities);
             // Check if previous cantus stepped up
-            if (ruleInput.PreviousCantus < ruleInput.CurrentNote)
+            if (ruleInput.PreviousCantus.Pitch < ruleInput.CurrentNote.Pitch)
             {
                 // Check if previous counterpoint was the higher voice
-                if(ruleInput.PreviousCounterpoint > ruleInput.PreviousCantus)
+                if(ruleInput.PreviousCounterpoint.Pitch > ruleInput.PreviousCantus.Pitch)
                 {
                     // Remove upper octave as a possibility
-                    output.Remove(ruleInput.CurrentNote + 13);
+                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13);
+                    // TODO: This probably doesn't work, recheck this
+                    output.Remove(removeNote);
                 }
             }
             // Check if previous cantus stepped down
-            else if (ruleInput.PreviousCantus > ruleInput.CurrentNote)
+            else if (ruleInput.PreviousCantus.Pitch > ruleInput.CurrentNote.Pitch)
             {
                 // Check if previous counterpoint was the lower voice
-                if(ruleInput.PreviousCounterpoint < ruleInput.PreviousCantus)
+                if(ruleInput.PreviousCounterpoint.Pitch < ruleInput.PreviousCantus.Pitch)
                 {
                     // Remove lower octave as a possibility
-                    output.Remove(ruleInput.CurrentNote - 13);
+                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13);
+                    // TODO: This probably doesn't work, recheck this
+                    output.Remove(removeNote);
                 }
             }
             return output;

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -29,9 +29,8 @@ namespace CounterpointGenerator
                 if(ruleInput.PreviousCounterpoint.Pitch > ruleInput.PreviousCantus.Pitch)
                 {
                     // Remove upper octave as a possibility
-                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13);
-                    // TODO: This probably doesn't work, recheck this
-                    output.Remove(removeNote);
+                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch + 13, ruleInput.CurrentNote.Length);
+                    output.RemoveAll(n => n.Pitch == removeNote.Pitch);
                 }
             }
             // Check if previous cantus stepped down
@@ -41,9 +40,8 @@ namespace CounterpointGenerator
                 if(ruleInput.PreviousCounterpoint.Pitch < ruleInput.PreviousCantus.Pitch)
                 {
                     // Remove lower octave as a possibility
-                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13);
-                    // TODO: This probably doesn't work, recheck this
-                    output.Remove(removeNote);
+                    Note removeNote = new Note(ruleInput.CurrentNote.Pitch - 13, ruleInput.CurrentNote.Length);
+                    output.RemoveAll(n => n.Pitch == removeNote.Pitch);
                 }
             }
             return output;

--- a/CounterpointGenerator/CounterpointGenerator/Rules/IRuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/IRuleApplier.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CounterpointGenerator.Rules
+{
+    public interface IRuleApplier
+    {
+        public Boolean GenerateSet();
+
+        public void Applicator(RuleInput ruleInput);
+    }
+}

--- a/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
@@ -8,23 +8,23 @@ namespace CounterpointGenerator {
      */
     public interface IRules
     {
-        public List<int> Apply(RuleInput ruleInput);
+        public List<Note> Apply(RuleInput ruleInput);
     }
 
     public class RuleInput
     {
         // Range of possible notes
-        public List<int> Possibilities { get; set; }
+        public List<Note> Possibilities { get; set; }
         // Current cantus note in generation
-        public int CurrentNote { get; set; }
+        public Note CurrentNote { get; set; }
         // Current position in generation, current count of notes
         public int Position { get; set; }
         // Total expected length of generation
         public int Length { get; set; }
         // Previous cantus note
-        public int PreviousCantus { get; set; }
+        public Note PreviousCantus { get; set; }
         //Previous counterpoint note
-        public int PreviousCounterpoint { get; set; }
+        public Note PreviousCounterpoint { get; set; }
     }
 
 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
@@ -25,6 +25,16 @@ namespace CounterpointGenerator {
         public Note PreviousCantus { get; set; }
         //Previous counterpoint note
         public Note PreviousCounterpoint { get; set; }
+
+        public RuleInput(List<Note> possi, Note curN, int pos, int len, Note prevCan, Note prevCou)
+        {
+            this.Possibilities = possi;
+            this.CurrentNote = curN;
+            this.Position = pos;
+            this.Length = len;
+            this.PreviousCantus = prevCan;
+            this.PreviousCounterpoint = prevCou;
+        }
     }
 
 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CounterpointGenerator
+{
+    class RuleApplier
+    {
+        private List<IRules> ruleSet = new List<IRules>();
+
+        public Boolean generateSet()
+        {
+            // Build ruleset
+            ruleSet.Add(new StartEndPerfectRule());
+            ruleSet.Add(new PenultimateNoteRule());
+            ruleSet.Add(new BattutaRule());
+
+            // Return true if all rules added
+            if (ruleSet.Count == 3)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void Applicator (RuleInput ruleInput)
+        {
+            foreach (IRules r in ruleSet)
+            {
+                ruleInput.Possibilities = r.Apply(ruleInput);
+            }
+        }
+    }
+}

--- a/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace CounterpointGenerator
 {
-    class RuleApplier
+    public class RuleApplier: Rules.IRuleApplier
     {
         private List<IRules> ruleSet = new List<IRules>();
 

--- a/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
@@ -5,7 +5,12 @@ namespace CounterpointGenerator
 {
     public class RuleApplier: Rules.IRuleApplier
     {
-        private List<IRules> ruleSet = new List<IRules>();
+        private List<IRules> ruleSet;
+
+        public RuleApplier()
+        {
+            ruleSet = new List<IRules>();
+        }
 
         public Boolean GenerateSet()
         {

--- a/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
@@ -21,14 +21,7 @@ namespace CounterpointGenerator
             ruleSet.Add(new BattutaRule());
 
             // Return true if all rules added
-            if (ruleSet.Count == 3)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return ruleSet.Count == 3;
         }
 
         public void Applicator (RuleInput ruleInput)

--- a/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/RuleApplier.cs
@@ -7,9 +7,10 @@ namespace CounterpointGenerator
     {
         private List<IRules> ruleSet = new List<IRules>();
 
-        public Boolean generateSet()
+        public Boolean GenerateSet()
         {
             // Build ruleset
+            // Non-weighted rules, weighted chance rules to be handled elsewhere
             ruleSet.Add(new StartEndPerfectRule());
             ruleSet.Add(new PenultimateNoteRule());
             ruleSet.Add(new BattutaRule());
@@ -27,6 +28,7 @@ namespace CounterpointGenerator
 
         public void Applicator (RuleInput ruleInput)
         {
+            // Mutate ruleInput.Possibilities, result and logic will need testing
             foreach (IRules r in ruleSet)
             {
                 ruleInput.Possibilities = r.Apply(ruleInput);

--- a/CounterpointGenerator/CounterpointGenerator/Rules/imperfectConsonanceRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/imperfectConsonanceRule.cs
@@ -19,11 +19,11 @@ namespace CounterpointGenerator {
         /**
          * INPUTS: Possibilities, CurrentNote
          */
-        public List<int> Apply(RuleInput ruleInput){
-            List<int> output = new List<int>();
-            foreach (int n in ruleInput.Possibilities) {
+        public List<Note> Apply(RuleInput ruleInput){
+            List<Note> output = new List<Note>();
+            foreach (Note n in ruleInput.Possibilities) {
                 // Add checking outside one octave range?
-                if (imperfectIntervals.Contains(n - ruleInput.CurrentNote)){
+                if (imperfectIntervals.Contains(n.Pitch - ruleInput.CurrentNote.Pitch)){
                     //If the difference between not in possibilities n is equal to an imperfect interval
                     output.Add(n);
                 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
@@ -9,17 +9,17 @@ namespace CounterpointGenerator{
          * For a note higher than the cantus firmus it must be a minor third
          * This means the legal note is either three semitones up or three semitones down
          */
-        private readonly List<int> legalNotes = new List<int>(){-3, 3};
+        private readonly List<int> legalIntervals = new List<int>(){-3, 3};
 
         /**
          * INPUTS: Possibilities, CurrentNote, Position, Length
          */
-        public List<int> Apply(RuleInput ruleInput) {
+        public List<Note> Apply(RuleInput ruleInput) {
             if (ruleInput.Length - ruleInput.Position == 1){
                 // If we're in the penultimate note
-                List<int> output = new List<int>();
-                foreach (int n in ruleInput.Possibilities) {
-                    if(legalNotes.Contains(n - ruleInput.CurrentNote)){
+                List<Note> output = new List<Note>();
+                foreach (Note n in ruleInput.Possibilities) {
+                    if(legalIntervals.Contains(n.Pitch - ruleInput.CurrentNote.Pitch)){
                         output.Add(n);
                     }
                 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/perfectConsonanceRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/perfectConsonanceRule.cs
@@ -20,11 +20,11 @@ namespace CounterpointGenerator {
         /**
          * INPUTS: Possibilities, CurrentNote
          */
-        public List<int> Apply(RuleInput ruleInput) {
-            List<int> output = new List<int>();
-            foreach (int n in ruleInput.Possibilities) {
+        public List<Note> Apply(RuleInput ruleInput) {
+            List<Note> output = new List<Note>();
+            foreach (Note n in ruleInput.Possibilities) {
                 // Add checking for perfect fourth/fifth outside one octave difference?
-                if (perfectIntervals.Contains(n - ruleInput.CurrentNote)){
+                if (perfectIntervals.Contains(n.Pitch - ruleInput.CurrentNote.Pitch)){
                     //If the difference between note in possibilities n is
                     //equal to a perfect interval
                     output.Add(n);

--- a/CounterpointGenerator/CounterpointGenerator/Rules/startEndPerfectRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/startEndPerfectRule.cs
@@ -10,7 +10,7 @@ namespace CounterpointGenerator{
         /**
          * INPUTS: Possibilities, CurrentNote, Position, Length
          */
-        public List<int> Apply(RuleInput ruleInput){
+        public List<Note> Apply(RuleInput ruleInput){
             if (ruleInput.Position == 0 || ruleInput.Position == ruleInput.Length){
                 // If we're in the first or last note
                 PerfectConsonanceRule reuseCode = new PerfectConsonanceRule();


### PR DESCRIPTION
~~Currently (22/JUL) exists to show code, not ready for merge or full review yet.~~

Resolves https://github.com/theanticrumpet/CounterpointGenerator/issues/10

Adds RuleApplier class for non-weighted rules, builds ruleset using `GenerateRuleset()` method and then `Applicator()` method can be called with a ruleInput parameter to step through each rule and trim down the possibilities list.

-----

Changes to Generator:
> Implement GenerateNoteAtRegion to return a List<Note> of every note from (n.Pitch -13) to (n.Pitch +13)
> Redone CounterpointForNote to take in all input required for a full ruleInput and use the RuleApplier.GenerateSet() and RuleApplier.Applicator(RuleInput ri) methods
> Adjusted parameters of GenerateCounterpointForNoteStack

Changes to Note:
> Added constructors for default length and to provide length
> Added Note.Equals(Note n) method

Changes to MelodyLine:
> Added MelodyLine.Length() method

Changes to RuleInput:
> Added constructor

Changes to Rules:
> Now use Note objects with Note.Pitch instead of just raw ints
> Battuta specific: Added position == 0 case, Fixed note removal logic to work with objects instead of the much easier raw int