### PR TITLE
Recount semitones

### DIFF
--- a/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
+++ b/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
@@ -11,9 +11,9 @@ namespace _3_1_GeneratorTests
     {
         private readonly List<int> intervalIntList = new List<int>()
         {
-            -12, -11, -10, -9, -8, -7, -6, -5,
+            -13, -12, -11, -10, -9, -8, -7, -6, -5,
             -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,
-            8, 9, 10, 11, 12
+            8, 9, 10, 11, 12, 13
         };
         private List<Note> defaultNoteList = new List<Note>();
 
@@ -38,7 +38,7 @@ namespace _3_1_GeneratorTests
         public void Test_ImperfectConsonance()
         {
             List<Note> testRange = new List<Note>(defaultNoteList);
-            Note spoofCurrentNote = new Note(Constants.C5);
+            Note spoofCurrentNote = new Note(0); // C5
             RuleInput ri = new RuleInput
             {
                 CurrentNote = spoofCurrentNote,
@@ -48,7 +48,7 @@ namespace _3_1_GeneratorTests
             ImperfectConsonanceRule icr = new ImperfectConsonanceRule();
             List<Note> resultRangeNote = icr.Apply(ri);
 
-            List<int> expectedRange = new List<int>(Constants.IMPERFECT_INTERVALS);
+            List<int> expectedRange = new List<int>() { -9, -8, -4, -3, 3, 4, 8, 9 };
             List<int> resultRange = new List<int>(resultRangeNote.Select(n => n.Pitch));
 
             Console.WriteLine(string.Join(", ", expectedRange));

--- a/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
+++ b/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
@@ -11,9 +11,9 @@ namespace _3_1_GeneratorTests
     {
         private readonly List<int> intervalIntList = new List<int>()
         {
-            -13, -12, -11, -10, -9, -8, -7, -6, -5,
+            -12, -11, -10, -9, -8, -7, -6, -5,
             -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,
-            8, 9, 10, 11, 12, 13
+            8, 9, 10, 11, 12
         };
         private List<Note> defaultNoteList = new List<Note>();
 
@@ -38,7 +38,7 @@ namespace _3_1_GeneratorTests
         public void Test_ImperfectConsonance()
         {
             List<Note> testRange = new List<Note>(defaultNoteList);
-            Note spoofCurrentNote = new Note(0); // C5
+            Note spoofCurrentNote = new Note(Constants.C5);
             RuleInput ri = new RuleInput
             {
                 CurrentNote = spoofCurrentNote,
@@ -48,7 +48,7 @@ namespace _3_1_GeneratorTests
             ImperfectConsonanceRule icr = new ImperfectConsonanceRule();
             List<Note> resultRangeNote = icr.Apply(ri);
 
-            List<int> expectedRange = new List<int>() { -9, -8, -4, -3, 3, 4, 8, 9 };
+            List<int> expectedRange = new List<int>(Constants.IMPERFECT_INTERVALS);
             List<int> resultRange = new List<int>(resultRangeNote.Select(n => n.Pitch));
 
             Console.WriteLine(string.Join(", ", expectedRange));

--- a/CounterpointGenerator/CounterpointGenerator/Constants.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Constants.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CounterpointGenerator
+{
+    class Constants
+    {
+        // REFERENCE NOTE
+        public static int C5 = 0;
+
+        // INTERVALS
+        /*
+         * Counted around the idea that C5 = 0
+         * Counted number of semitones between notes
+         * For example C5 = 0, G5 = 7
+         * Therefore a fifth = 7 - 0 = 7
+         * 
+         * A "lower" version of an interval is the same pitch,
+         * but then lowered an octave
+         * F5 is five semitones higher than C5
+         * but F4 is seven semitones lower than C5
+         */
+
+        // PERFECT
+        public static int OCTAVE = 12;
+        public static int OCTAVE_DOWN = -12;
+        public static int UPPER_FOURTH = 5;
+        public static int LOWER_FOURTH = -7;
+        public static int UPPER_FIFTH = 7;
+        public static int LOWER_FIFTH = -5;
+
+        // IMPERFECT
+        public static int UPPER_MINOR_THIRD = 3;
+        public static int LOWER_MINOR_THIRD = -9;
+        public static int UPPER_MAJOR_THIRD = 4;
+        public static int LOWER_MAJOR_THIRD = -8;
+        public static int UPPER_MINOR_SIXTH = 8;
+        public static int LOWER_MINOR_SIXTH = -4;
+        public static int UPPER_MAJOR_SIXTH = 9;
+        public static int LOWER_MAJOR_SIXTH = -3;
+    }
+}

--- a/CounterpointGenerator/CounterpointGenerator/Constants.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Constants.cs
@@ -30,6 +30,16 @@ namespace CounterpointGenerator
         public static int UPPER_FIFTH = 7;
         public static int LOWER_FIFTH = -5;
 
+        public static readonly List<int> PERFECT_INTERVALS = new List<int>()
+        {
+            OCTAVE_DOWN,
+            LOWER_FIFTH,
+            LOWER_FOURTH,
+            UPPER_FOURTH,
+            UPPER_FIFTH,
+            OCTAVE
+        };
+
         // IMPERFECT
         public static int UPPER_MINOR_THIRD = 3;
         public static int LOWER_MINOR_THIRD = -9;
@@ -39,5 +49,17 @@ namespace CounterpointGenerator
         public static int LOWER_MINOR_SIXTH = -4;
         public static int UPPER_MAJOR_SIXTH = 9;
         public static int LOWER_MAJOR_SIXTH = -3;
+
+        public static readonly List<int> IMPERFECT_INTERVALS = new List<int>()
+        {
+            LOWER_MINOR_THIRD,
+            LOWER_MAJOR_THIRD,
+            LOWER_MINOR_SIXTH,
+            LOWER_MAJOR_SIXTH,
+            UPPER_MINOR_THIRD,
+            UPPER_MAJOR_THIRD,
+            UPPER_MINOR_SIXTH,
+            UPPER_MAJOR_SIXTH
+        };
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -14,19 +14,27 @@ namespace CounterpointGenerator
             return GenerateCounterpointForNoteStack(inputCantusfirmus, null, null, 0, inputCantusfirmus.Length()-1);
         }
 
-        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote, int count, int fullLength)
+        private List<MelodyLine> GenerateCounterpointForNoteStack(MelodyLine m, Note? previousNote, Note? previousCounterNote, int count, int endOn)
         {
             Note n = m.FirstNote;
-            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, fullLength, count);
+            List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, endOn, count);
 
             List<MelodyLine> solutionList = new List<MelodyLine>();
 
             // Rules need a RuleInput object input to function
-            RuleInput ri = new RuleInput(possibilitiesAfterRules, n, count, fullLength, previousNote, previousCounterNote);
+            RuleInput ri = new RuleInput
+            {
+                Possibilities = possibilitiesAfterRules,
+                CurrentNote = n,
+                Position = count,
+                EndOn = endOn,
+                PreviousCantus = previousNote,
+                PreviousCounterpoint = previousCounterNote
+            };
             IWeightSelect weightSelector = new WeightSelect(ri);
             List<Note> subListToExplore = weightSelector.SelectPossibilities();
 
-            if (fullLength == count)
+            if (endOn == count)
             {
                 return subListToExplore
                     .Select(note => new MelodyLine(new List<Note> { note }))
@@ -52,11 +60,19 @@ namespace CounterpointGenerator
 
         }
 
-        private List<Note> CounterpointForNote(Note n, Note prevN, Note preCtp, int melodyLength, int generateCount)
+        private List<Note> CounterpointForNote(Note n, Note prevN, Note preCtp, int endOn, int generateCount)
         {
             List<Note> possibleNotes = GenerateNoteAtRegion(n);
-            // Possibilities, currentNote, position, length, previousCantus, previousCounterpoint
-            RuleInput ruleInput = new RuleInput(possibleNotes, n, generateCount, melodyLength, prevN, preCtp);
+
+            RuleInput ruleInput = new RuleInput
+            {
+                Possibilities = possibleNotes,
+                CurrentNote = n,
+                Position = generateCount,
+                EndOn = endOn,
+                PreviousCantus = prevN,
+                PreviousCounterpoint = preCtp
+            };
 
             ruleApplier = new RuleApplier();
             if (ruleApplier.GenerateSet())
@@ -73,6 +89,7 @@ namespace CounterpointGenerator
 
         private List<Note> GenerateNoteAtRegion(Note n)
         {
+            // Only make notes from the correct intervals in the first place
             List<int> intervals = new List<int>(Constants.PERFECT_INTERVALS);
             intervals.AddRange(Constants.IMPERFECT_INTERVALS);
 

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -73,13 +73,15 @@ namespace CounterpointGenerator
 
         private List<Note> GenerateNoteAtRegion(Note n)
         {
-            int upperPitch = n.Pitch + Note.OCTAVE; // +1 octave
-            int lowerPitch = n.Pitch - Note.OCTAVE; // -1 octave
+            List<int> intervals = new List<int>(Constants.PERFECT_INTERVALS);
+            intervals.AddRange(Constants.IMPERFECT_INTERVALS);
+
             List<Note> output = new List<Note>();
-            for (int addPitch = lowerPitch; addPitch <= upperPitch; addPitch++)
+
+            foreach (int interval in intervals)
             {
                 // TODO: Fix for note length when that becomes something to worry about
-                output.Add(new Note(addPitch));
+                output.Add(new Note(n.Pitch + interval));
             }
             return output;
         }

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -46,7 +46,7 @@ namespace CounterpointGenerator
             foreach (Note p in subListToExplore)
             {
 
-                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(new MelodyLine(m.AMelodyLine), n, p, count + 1, fullLength);
+                List<MelodyLine> melodyList = GenerateCounterpointForNoteStack(new MelodyLine(m.AMelodyLine), n, p, count + 1, endOn);
                 List<MelodyLine> solution = new List<MelodyLine>();
                 foreach (MelodyLine line in melodyList)
                 {

--- a/CounterpointGenerator/CounterpointGenerator/Note.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Note.cs
@@ -4,7 +4,7 @@ namespace CounterpointGenerator
     public class Note
     {
         // One octave is thirteen semitones
-        public static int OCTAVE = 13;
+        //public static int OCTAVE = 13;
 
         public int Pitch { get; set; }
         public int Length { get; set; } = 4; //Measure in beats, default whole note

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -29,7 +29,7 @@ namespace CounterpointGenerator
             {
                 // Remove upper octave as a possibility
                 // Remove all items n such that n's pitch is equal to the removeNote pitch
-                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch + Note.OCTAVE);
+                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch + Constants.OCTAVE);
             }
             // Check if previous cantus stepped down
             // Check if previous counterpoint was the lower voice
@@ -38,7 +38,7 @@ namespace CounterpointGenerator
             {
                 // Remove lower octave as a possibility
                 // Remove all items n such that n's pitch is equal to the removeNote pitch
-                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch - Note.OCTAVE);
+                output.RemoveAll(n => n.Pitch == ruleInput.CurrentNote.Pitch - Constants.OCTAVE);
             }
             return output;
         }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/IRules.cs
@@ -18,23 +18,15 @@ namespace CounterpointGenerator {
         // Current cantus note in generation
         public Note CurrentNote { get; set; }
         // Current position in generation, current count of notes
+        // 0-indexed!
         public int Position { get; set; }
         // Total expected length of generation
-        public int Length { get; set; }
+        // 0-indexed, too!
+        public int EndOn { get; set; }
         // Previous cantus note
         public Note PreviousCantus { get; set; }
         //Previous counterpoint note
         public Note PreviousCounterpoint { get; set; }
-
-        public RuleInput(List<Note> possi, Note curN, int pos, int len, Note prevCan, Note prevCou)
-        {
-            this.Possibilities = possi;
-            this.CurrentNote = curN;
-            this.Position = pos;
-            this.Length = len;
-            this.PreviousCantus = prevCan;
-            this.PreviousCounterpoint = prevCou;
-        }
 
         public RuleInput()
         {

--- a/CounterpointGenerator/CounterpointGenerator/Rules/imperfectConsonanceRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/imperfectConsonanceRule.cs
@@ -14,7 +14,7 @@ namespace CounterpointGenerator {
          */
 
         //Includes one octave up or down
-        private readonly List<int> imperfectIntervals =  new List<int>(){-9, -8, -4, -3, 3, 4, 8, 9};
+        private readonly List<int> imperfectIntervals =  new List<int>(Constants.IMPERFECT_INTERVALS);
 
         /**
          * INPUTS: Possibilities, CurrentNote

--- a/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
@@ -9,7 +9,11 @@ namespace CounterpointGenerator{
          * For a note higher than the cantus firmus it must be a minor third
          * This means the legal note is either three semitones up or three semitones down
          */
-        private readonly List<int> legalIntervals = new List<int>(){-3, 3};
+        private readonly List<int> legalIntervals = new List<int>()
+        {
+            Constants.LOWER_MAJOR_SIXTH,
+            Constants.UPPER_MINOR_THIRD
+        };
 
         /**
          * INPUTS: Possibilities, CurrentNote, Position, Length

--- a/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/penultimateNoteRule.cs
@@ -19,7 +19,7 @@ namespace CounterpointGenerator{
          * INPUTS: Possibilities, CurrentNote, Position, Length
          */
         public List<Note> Apply(RuleInput ruleInput) {
-            if (ruleInput.Length - ruleInput.Position == 1){
+            if (ruleInput.EndOn - ruleInput.Position == 1){
                 // If we're in the penultimate note
                 List<Note> output = new List<Note>();
                 foreach (Note n in ruleInput.Possibilities) {

--- a/CounterpointGenerator/CounterpointGenerator/Rules/perfectConsonanceRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/perfectConsonanceRule.cs
@@ -13,9 +13,9 @@ namespace CounterpointGenerator {
          * down the fifth and fourth are reversed
          */
 
-         //Includes one octave up or down
-         // {8vb, lower fifth, lower fourth, upper fourth, upper fifth, 8va}
-        private List<int> perfectIntervals = new List<int>(){-12, -7, -5, 5, 7, 12};
+        //Includes one octave up or down
+        // {8vb, lower fifth, lower fourth, upper fourth, upper fifth, 8va}
+        private List<int> perfectIntervals = new List<int>(Constants.PERFECT_INTERVALS);
 
         /**
          * INPUTS: Possibilities, CurrentNote

--- a/CounterpointGenerator/CounterpointGenerator/Rules/startEndPerfectRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/startEndPerfectRule.cs
@@ -11,7 +11,7 @@ namespace CounterpointGenerator{
          * INPUTS: Possibilities, CurrentNote, Position, Length
          */
         public List<Note> Apply(RuleInput ruleInput){
-            if (ruleInput.Position == 0 || ruleInput.Position == ruleInput.Length){
+            if (ruleInput.Position == 0 || ruleInput.Position == ruleInput.EndOn){
                 // If we're in the first or last note
                 PerfectConsonanceRule reuseCode = new PerfectConsonanceRule();
                 return reuseCode.Apply(ruleInput);


### PR DESCRIPTION
Resolves https://github.com/theanticrumpet/CounterpointGenerator/issues/20

Not as expansive as I was expecting.

Creates a Constants.CS file which now acts as a standard place for interval counts, interval lists, and a reference note. Should be even easier to adjust in the future.

Changes the ruleinput declarations in generator to something I learned doing the unit test work, in my opinion is much clearer than a long constructor with many parameters. Also makes it so `GenerateNoteAtRegion()` starts with only proper intervals instead of just every note from -13 to +13