### PR TITLE
More rules unittests

### DIFF
--- a/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
+++ b/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
@@ -151,6 +151,10 @@ namespace _3_1_GeneratorTests
         [TestMethod]
         public void Test_Penultimate()
         {
+
+            //TODO: This needs to be redone because some stuff changed in the meeting
+
+
             List<Note> testRange = new List<Note>(defaultNoteList);
             Note spoofCurrentNote = new Note(0); //C5
 

--- a/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
+++ b/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
@@ -147,5 +147,35 @@ namespace _3_1_GeneratorTests
             // Did nothing happen?
             CollectionAssert.AreEquivalent(cantusDown.Possibilities, cantDwnResultNote2);
         }
+
+        [TestMethod]
+        public void Test_Penultimate()
+        {
+            List<Note> testRange = new List<Note>(defaultNoteList);
+            Note spoofCurrentNote = new Note(0); //C5
+
+            // First, out of position test
+            RuleInput ri = new RuleInput
+            {
+                CurrentNote = spoofCurrentNote,
+                Possibilities = testRange,
+                Position = 0,
+                Length = 10
+            };
+
+            PenultimateNoteRule pnr = new PenultimateNoteRule();
+            List<Note> outOfPositionResult = pnr.Apply(ri);
+            // Did nothing happen?
+            CollectionAssert.AreEquivalent(testRange, outOfPositionResult);
+
+            // Set the position to be in the correct space
+            ri.Position = 9;
+            List<Note> resultRangeNote = pnr.Apply(ri);
+
+            List<int> expectedRange = new List<int>() { -3, 3 };
+            List<int> resultRange = new List<int>(resultRangeNote.Select(n => n.Pitch));
+            CollectionAssert.AreEquivalent(expectedRange, resultRange);
+
+        }
     }
 }

--- a/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
+++ b/CounterpointGenerator/3 1 GeneratorTests/3 1 RulesTest.cs
@@ -77,5 +77,75 @@ namespace _3_1_GeneratorTests
             Console.WriteLine(string.Join(", ", resultRange));
             CollectionAssert.AreEquivalent(expectedRange, resultRange);
         }
+
+        [TestMethod]
+        public void Test_Battuta()
+        {
+            List<Note> testRange = new List<Note>(defaultNoteList);
+            Note spoofCurrentNote = new Note(0); //C5
+            BattutaRule br = new BattutaRule();
+
+            RuleInput wrongPosition = new RuleInput
+            {
+                // Should return just Possibilities since Position == 0
+                CurrentNote = spoofCurrentNote,
+                Possibilities = testRange,
+                Position = 0
+            };
+            List<Note> wrongPositionResultNote = br.Apply(wrongPosition);
+
+            // Did nothing happen?
+            CollectionAssert.AreEquivalent(testRange, wrongPositionResultNote);
+
+            RuleInput cantusUp = new RuleInput
+            {
+                // Cantus is stepping up, counterpoint is the higher voice
+                CurrentNote = spoofCurrentNote,
+                Possibilities = testRange,
+                Position = 1,
+                PreviousCantus = new Note(-1), // B5
+                PreviousCounterpoint = new Note(7) // G5
+            };
+            List<Note> cantUpResultNote = br.Apply(cantusUp);
+
+            List<int> expectedRange = new List<int>(intervalIntList);
+            expectedRange.Remove(13);
+            List<int> resultRange = new List<int>(cantUpResultNote.Select(n => n.Pitch));
+            // Was 8va removed as a possibility?
+            CollectionAssert.AreEquivalent(expectedRange, resultRange);
+
+            // Cantus is stepping up, counterpoint is lower voice
+            // Should just return a new list equal to Possibilities
+            cantusUp.PreviousCounterpoint = new Note(-5); // G4
+            List<Note> cantUpResultNote2 = br.Apply(cantusUp);
+
+            // Did nothing happen?
+            CollectionAssert.AreEquivalent(cantusUp.Possibilities, cantUpResultNote2);
+
+            RuleInput cantusDown = new RuleInput
+            {
+                // Cantus is stepping down, counterpoint is lower voice
+                CurrentNote = spoofCurrentNote,
+                Possibilities = testRange,
+                Position = 1,
+                PreviousCantus = new Note(5), // F5
+                PreviousCounterpoint = new Note(-1) // B5
+            };
+            List<Note> cantDwnResultNote = br.Apply(cantusDown);
+
+            expectedRange = new List<int>(intervalIntList);
+            expectedRange.Remove(-13);
+            resultRange = new List<int>(cantDwnResultNote.Select(n => n.Pitch));
+            // Was 8vb removed as a possibility?
+            CollectionAssert.AreEquivalent(expectedRange, resultRange);
+
+            // Cantus is stepping down, counterpoint is higher voice
+            // Should just return a new list equal to Possibilities
+            cantusDown.PreviousCounterpoint = new Note(13); // C6
+            List<Note> cantDwnResultNote2 = br.Apply(cantusDown);
+
+            // Did nothing happen?
+            CollectionAssert.AreEquivalent(cantusDown.Possibilities, cantDwnResultNote2);
+        }
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Rules/BattutaRule.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace CounterpointGenerator
 {
-    class BattutaRule : IRules
+    public class BattutaRule : IRules
     {
         /**
          * An octave cannot be met by stepping down in the higher voice and up in the lower voice


### PR DESCRIPTION
Forgot to PR this from earlier. This just adds some more unit testing to the rules.

Does not finish https://github.com/theanticrumpet/CounterpointGenerator/issues/16 but I need this in either before https://github.com/theanticrumpet/CounterpointGenerator/pull/24 gets merged or at the same time to then fix all the unit testing with the new constants system (and add more testing that I think is needed)