### PR TITLE
Weightselector fix

### DIFF
--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -40,7 +40,8 @@ namespace CounterpointGenerator
             };
             */
             
-            List<Note> subListToExplore = _weightSelector.SelectPossibilities(possibilitiesAfterRules);
+            // weightSelector needs at least the current note so the interval math can be checked
+            List<Note> subListToExplore = _weightSelector.SelectPossibilities(possibilitiesAfterRules, n);
 
             if (endOn == count)
             {

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -8,6 +8,12 @@ namespace CounterpointGenerator
     public class Generator: IGenerator
     {
         private RuleApplier ruleApplier;
+        private IWeightSelect _weightSelector;
+
+        public Generator(IWeightSelect weightSelector)
+        {
+            _weightSelector = weightSelector;
+        }
 
         private List<MelodyLine> GenerateCounterpoint(MelodyLine inputCantusfirmus)
         {
@@ -21,6 +27,7 @@ namespace CounterpointGenerator
 
             List<MelodyLine> solutionList = new List<MelodyLine>();
 
+            /*
             // Rules need a RuleInput object input to function
             RuleInput ri = new RuleInput
             {
@@ -31,8 +38,9 @@ namespace CounterpointGenerator
                 PreviousCantus = previousNote,
                 PreviousCounterpoint = previousCounterNote
             };
-            IWeightSelect weightSelector = new WeightSelect(ri);
-            List<Note> subListToExplore = weightSelector.SelectPossibilities();
+            */
+            
+            List<Note> subListToExplore = _weightSelector.SelectPossibilities(possibilitiesAfterRules);
 
             if (endOn == count)
             {

--- a/CounterpointGenerator/CounterpointGenerator/Generator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Generator.cs
@@ -26,19 +26,6 @@ namespace CounterpointGenerator
             List<Note> possibilitiesAfterRules = CounterpointForNote(n, previousNote, previousCounterNote, endOn, count);
 
             List<MelodyLine> solutionList = new List<MelodyLine>();
-
-            /*
-            // Rules need a RuleInput object input to function
-            RuleInput ri = new RuleInput
-            {
-                Possibilities = possibilitiesAfterRules,
-                CurrentNote = n,
-                Position = count,
-                EndOn = endOn,
-                PreviousCantus = previousNote,
-                PreviousCounterpoint = previousCounterNote
-            };
-            */
             
             // weightSelector needs at least the current note so the interval math can be checked
             List<Note> subListToExplore = _weightSelector.SelectPossibilities(possibilitiesAfterRules, n);

--- a/CounterpointGenerator/CounterpointGenerator/IweightSelector.cs
+++ b/CounterpointGenerator/CounterpointGenerator/IweightSelector.cs
@@ -5,6 +5,6 @@ namespace CounterpointGenerator
 {
     public interface IWeightSelect
     {
-        public List<Note> SelectPossibilities(List<Note> selectFrom);
+        public List<Note> SelectPossibilities(List<Note> selectFrom, Note currentNote);
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/IweightSelector.cs
+++ b/CounterpointGenerator/CounterpointGenerator/IweightSelector.cs
@@ -5,6 +5,6 @@ namespace CounterpointGenerator
 {
     public interface IWeightSelect
     {
-        public List<Note> SelectPossibilities();
+        public List<Note> SelectPossibilities(List<Note> selectFrom);
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Program.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Program.cs
@@ -24,7 +24,8 @@ namespace CounterpointGenerator
                             // For now, registering mocks.
                             .AddSingleton<IInputTranslator, InputTranslator>()
                             .AddSingleton<IGenerator, Generator>()
-                            .AddSingleton<IOutputTranslator, OutputTranslator>());
+                            .AddSingleton<IOutputTranslator, OutputTranslator>()
+                            .AddSingleton<IWeightSelect, WeightSelect>());
         // Let's make everything a singleton for now.
         // Depending on the implementation might make sense to have generator be transient.
 

--- a/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
+++ b/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
@@ -20,6 +20,7 @@ namespace CounterpointGenerator
 
             List<Note> output = new List<Note>();
             List<Note> mutate = new List<Note>(selectFrom);
+            Shuffle(mutate);
             int failCount = 0;
 
             while(output.Count <= maximumCount)
@@ -66,6 +67,21 @@ namespace CounterpointGenerator
             }
 
             return output;
+        }
+
+        private void Shuffle<T>(IList<T> list)
+        {
+            // Shuffle method based on Fisher-Yates shuffle
+            // Shamelessly stolen from https://stackoverflow.com/questions/273313/randomize-a-listt
+            int n = list.Count;
+            while (n > 1)
+            {
+                n--;
+                int k = _rnd.Next(n + 1);
+                T value = list[k];
+                list[k] = list[n];
+                list[n] = value;
+            }
         }
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
+++ b/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
@@ -7,8 +7,13 @@ namespace CounterpointGenerator
     public class WeightSelect: IWeightSelect
     {
         private Random _rnd = new Random();
+        
+        // Maximum number of notes to select into
         public int maximumCount { get; set; } = 5;
+        // Maximum number of times the select if statements can fail to find anything before hard picking something
         public int maximumFail { get; set; } = 5;
+        // Chance that Imperfect Consonance is selected
+        public int imperfectChance { get; set; } = 75;
 
         public List<Note> SelectPossibilities(List<Note> selectFrom, Note currentNote)
         {
@@ -27,32 +32,32 @@ namespace CounterpointGenerator
             {
                 int chance = _rnd.Next(1, 101);
 
-                if(chance <= 75)
+                if(chance <= imperfectChance)
                 {
-                    failCount++; // Preemptively increment this
-                    foreach(Note n in mutate)
+                    Note n = mutate.Find(note => Constants.IMPERFECT_INTERVALS.Contains(note.Pitch - currentNote.Pitch));
+                    if(n == null)
                     {
-                        if (Constants.IMPERFECT_INTERVALS.Contains(n.Pitch - currentNote.Pitch))
-                        {
-                            output.Add(n);
-                            mutate.Remove(n);
-                            failCount = 0; // Reset to 0 on successful
-                            break;
-                        }
+                        failCount++;
+                    }
+                    else
+                    {
+                        output.Add(n);
+                        mutate.Remove(n);
+                        failCount = 0;
                     }
                 }
                 else
                 {
-                    failCount++; // Preemptively increment this
-                    foreach(Note n in mutate)
+                    Note n = mutate.Find(note => Constants.PERFECT_INTERVALS.Contains(note.Pitch - currentNote.Pitch));
+                    if(n == null)
                     {
-                        if (Constants.PERFECT_INTERVALS.Contains(n.Pitch - currentNote.Pitch))
-                        {
-                            output.Add(n);
-                            mutate.Remove(n);
-                            failCount = 0; // Reset to 0 on successful
-                            break;
-                        }
+                        failCount++;
+                    }
+                    else
+                    {
+                        output.Add(n);
+                        mutate.Remove(n);
+                        failCount = 0;
                     }
                 }
 

--- a/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
+++ b/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
@@ -43,7 +43,7 @@ namespace CounterpointGenerator
                 else
                 {
                     failCount++; // Preemptively increment this
-                    foreach(Note n in selectFrom)
+                    foreach(Note n in mutate)
                     {
                         if (Constants.PERFECT_INTERVALS.Contains(n.Pitch))
                         {

--- a/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
+++ b/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
@@ -1,40 +1,71 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CounterpointGenerator
 {
     public class WeightSelect: IWeightSelect
     {
-        Random _rnd = new Random();
-        RuleInput ri = new RuleInput();
+        private Random _rnd = new Random();
+        public int maximumCount { get; set; } = 5;
+        public int maximumFail { get; set; } = 5;
 
-        public WeightSelect(RuleInput ri)
+        public List<Note> SelectPossibilities(List<Note> selectFrom)
         {
-            // TODO: Add handling of user input
-            this.ri = ri;
-        }
-
-        public List<Note> SelectPossibilities()
-        {
-            // 80% of the time pick an imperfect consonance 
-            //IRules perfectOrImperfect = PickBetweenTwo(new ImperfectConsonanceRule(), 80,
-            //                                            new PerfectConsonanceRule());
-            //return perfectOrImperfect.Apply(this.ri);
-            return ri.Possibilities;
-        }
-
-        private IRules PickBetweenTwo(IRules ruleA, int ruleAChance, IRules ruleB)
-        {
-            // Given two rules and the chance for one (out of 100), pick one at random
-            int pickChance = _rnd.Next(1, 101);
-            if (pickChance <= ruleAChance)
+            if (selectFrom.Count <= maximumCount)
             {
-                return ruleA;
+                // Don't bother with weight selecting if there's already less than five notes to pick from
+                return selectFrom;
             }
-            else
+
+            List<Note> output = new List<Note>();
+            List<Note> mutate = new List<Note>(selectFrom);
+            int failCount = 0;
+
+            while(output.Count <= maximumCount)
             {
-                return ruleB;
+                int chance = _rnd.Next(1, 101);
+
+                if(chance <= 75)
+                {
+                    failCount++; // Preemptively increment this
+                    foreach(Note n in mutate)
+                    {
+                        if (Constants.IMPERFECT_INTERVALS.Contains(n.Pitch))
+                        {
+                            output.Add(n);
+                            mutate.Remove(n);
+                            failCount = 0; // Reset to 0 on successful
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    failCount++; // Preemptively increment this
+                    foreach(Note n in selectFrom)
+                    {
+                        if (Constants.PERFECT_INTERVALS.Contains(n.Pitch))
+                        {
+                            output.Add(n);
+                            mutate.Remove(n);
+                            failCount = 0; // Reset to 0 on successful
+                            break;
+                        }
+                    }
+                }
+
+                if (failCount > maximumFail)
+                {
+                    // Only find our way into here if failCount climbs on successive fails
+                    int justPickOne = _rnd.Next(0, mutate.Count);
+                    output.Add(mutate.ElementAt(justPickOne));
+                    mutate.RemoveAt(justPickOne);
+                    failCount = 0; // Reset to 0
+                }
             }
+
+            return output;
         }
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
+++ b/CounterpointGenerator/CounterpointGenerator/WeightSelect.cs
@@ -10,7 +10,7 @@ namespace CounterpointGenerator
         public int maximumCount { get; set; } = 5;
         public int maximumFail { get; set; } = 5;
 
-        public List<Note> SelectPossibilities(List<Note> selectFrom)
+        public List<Note> SelectPossibilities(List<Note> selectFrom, Note currentNote)
         {
             if (selectFrom.Count <= maximumCount)
             {
@@ -31,7 +31,7 @@ namespace CounterpointGenerator
                     failCount++; // Preemptively increment this
                     foreach(Note n in mutate)
                     {
-                        if (Constants.IMPERFECT_INTERVALS.Contains(n.Pitch))
+                        if (Constants.IMPERFECT_INTERVALS.Contains(n.Pitch - currentNote.Pitch))
                         {
                             output.Add(n);
                             mutate.Remove(n);
@@ -45,7 +45,7 @@ namespace CounterpointGenerator
                     failCount++; // Preemptively increment this
                     foreach(Note n in mutate)
                     {
-                        if (Constants.PERFECT_INTERVALS.Contains(n.Pitch))
+                        if (Constants.PERFECT_INTERVALS.Contains(n.Pitch - currentNote.Pitch))
                         {
                             output.Add(n);
                             mutate.Remove(n);


### PR DESCRIPTION
Resolves https://github.com/theanticrumpet/CounterpointGenerator/issues/19

Completely overhauls weight selector so instead of randomly picking a rule to apply it randomly picks a constants interval list to check and grab one note from the possibilities that matches.

By default this process repeats until you have a list of five notes, this can be changed by updating the generator's _weightSelector's maximumCount field

By default this process is allowed to fail five times in a row before it gives up and just picks a random note from possibilities and starts over in order to prevent getting stuck in long loops. This can be changed by updating the genrator's _weightSelector's maximumFail field