### PR TITLE
Added output collecting based on completeness

### DIFF
--- a/CounterpointGenerator/CounterpointGenerator/Constants.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Constants.cs
@@ -98,6 +98,10 @@ namespace CounterpointGenerator
         // Number of initial random notes to generate before rules
         public static int GIVE_ME_LOTS_OF_NOTES = 200;
 
-
+        // % error allowed in output collecting
+        // for considered "close to" completed
+        public static double OUTPUT_ERROR_MARGIN = 10.0;
+        // DEFAULT "10.0" means if a melody line is 90% of the way
+        // to complete it is "close to"
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/GeneratorBeats.cs
+++ b/CounterpointGenerator/CounterpointGenerator/GeneratorBeats.cs
@@ -131,7 +131,7 @@ namespace CounterpointGenerator
         public Task<IOutput> Generate(IInput input)
         {
             startTime = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeMilliseconds();
-            Output output = new Output();
+            Output output = new Output(input.Cantus.BeatCount());
             output.Cantus = GenerateCounterpoint(input.Cantus, input.userPreference);
             return Task.FromResult<IOutput>(output);
         }

--- a/CounterpointGenerator/CounterpointGenerator/IOutput.cs
+++ b/CounterpointGenerator/CounterpointGenerator/IOutput.cs
@@ -16,5 +16,10 @@ namespace CounterpointGenerator
         // Add something for the generated counterpoint.
 
         string ToString();
+
+        // Gather up entries in Cantus based on like features
+        void Collect();
+        string CompleteToString();
+        string CloseToToString();
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/Output.cs
+++ b/CounterpointGenerator/CounterpointGenerator/Output.cs
@@ -12,11 +12,48 @@ namespace CounterpointGenerator
         {
         }
 
+        public Output(double beatCount)
+        {
+            this.BeatCount = beatCount;
+        }
+
         public List<MelodyLine> Cantus { get; set; }
+        public List<MelodyLine> Complete;
+        public List<MelodyLine> CloseTo;
+        private double BeatCount;
 
         public override string ToString()
         {
             return Cantus.Count + "\n" + string.Join("\n", Cantus);
+        }
+
+        public void Collect()
+        {
+            Complete = new List<MelodyLine>();
+            CloseTo = new List<MelodyLine>();
+            foreach(MelodyLine ml in Cantus)
+            {
+                if (ml.BeatCount() == this.BeatCount)
+                {
+                    Complete.Add(ml);
+                }
+                else if (ml.BeatCount() / this.BeatCount >= (1 - (Constants.OUTPUT_ERROR_MARGIN / 100.0)))
+                {
+                    CloseTo.Add(ml);
+                }
+            }
+        }
+
+        public string CompleteToString()
+        {
+            //return Complete.Count + " Completed melodylines\n" + string.Join("\n", Complete);
+            return $"{Complete.Count} Completed melodylines\n{string.Join("\n", Complete)}";
+        }
+
+        public string CloseToToString()
+        {
+            return $"{CloseTo.Count} Melodylines within {Constants.OUTPUT_ERROR_MARGIN}% of completion\n" +
+                   $"{string.Join("\n", CloseTo)}";
         }
     }
 }

--- a/CounterpointGenerator/CounterpointGenerator/OutputTranslator.cs
+++ b/CounterpointGenerator/CounterpointGenerator/OutputTranslator.cs
@@ -11,8 +11,12 @@ namespace CounterpointGenerator
 
         public Task TranslateOutput(IOutput output)
         {
+            output.Collect();
+            
             Console.WriteLine("Output from counterpoint generator:");
-            Console.WriteLine(output.ToString());
+            Console.WriteLine(output.CompleteToString() + "\n");
+            Console.WriteLine(output.CloseToToString());
+            
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Resolves https://github.com/theanticrumpet/CounterpointGenerator/issues/34

Adds a new constant for percent error. Added function to collect all the melodylines in the output object's Cantus list into both a completed list, and a list where
```csharp
(line.BeatCount() / [EXPECTED_BEATCOUNT] ) >= 1 - ( [ERROR_MARGIN] / 100.0 )
```